### PR TITLE
Additional testing for views in DM_LADDERS_

### DIFF
--- a/.github/workflows/workflow-dev.yml
+++ b/.github/workflows/workflow-dev.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           pip install dbt-snowflake
           dbt deps    
-      - name: Run dbt models
-        run: dbt run --target dev
       - name: Test dbt models
         run: dbt test --target dev
+      - name: Run dbt models
+        run: dbt run --target dev

--- a/.github/workflows/workflow-prod.yml
+++ b/.github/workflows/workflow-prod.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           pip install dbt-snowflake
           dbt deps    
-      - name: Run dbt models
-        run: dbt run --target prod
       - name: Test dbt models
         run: dbt test --target prod
+      - name: Run dbt models
+        run: dbt run --target prod

--- a/.github/workflows/workflow-qa.yml
+++ b/.github/workflows/workflow-qa.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           pip install dbt-snowflake
           dbt deps    
-      - name: Run dbt models
-        run: dbt run --target qa
       - name: Test dbt models
         run: dbt test --target qa
+      - name: Run dbt models
+        run: dbt run --target qa

--- a/models/DM/dm_views_config.yml
+++ b/models/DM/dm_views_config.yml
@@ -14,9 +14,9 @@ models:
       tests:
       - not_null
       - unique
-      #- relationships:
-      #    to: source('dm_table_data', 'custoCASE_PROVIDERmers')
-      #    field: case_id      
+      - relationships:
+          to: source('dm_table_data', CASE_PROVIDER')
+          field: case_id      
     - name: CASE_TYPE
       tests:
       - not_null

--- a/models/DM/dm_views_config.yml
+++ b/models/DM/dm_views_config.yml
@@ -1,13 +1,22 @@
 models:
+  - name: VW_CLINIC_CREATE_UPDATE
+    columns:
+    - name: CLINIC_TYPE
+      tests:
+      - string_not_empty
+    columns:
+    - name: DISPLAY_NAME
+      tests:
+      - string_not_empty     
   - name: VW_CAPACITY_UPDATE
     columns:
     - name: CASE_ID
       tests:
       - not_null
       - unique
-      - relationships:
-          to: source('dm_table_data', 'CASE_PROVIDER')
-          field: case_id      
+      #- relationships:
+      #    to: source('dm_table_data', 'custoCASE_PROVIDERmers')
+      #    field: case_id      
     - name: CASE_TYPE
       tests:
       - not_null

--- a/models/DM/dm_views_config.yml
+++ b/models/DM/dm_views_config.yml
@@ -6,7 +6,7 @@ models:
       - not_null
       - unique
       - relationships:
-          to: source('dm_table_data', 'custoCASE_PROVIDERmers')
+          to: source('dm_table_data', CASE_PROVIDER')
           field: case_id      
     - name: CASE_TYPE
       tests:
@@ -14,7 +14,36 @@ models:
       - accepted_values:
           values: ['capacity']
       - string_not_empty
-    #- name: EXTERNAL_ID    
-    #  tests:
-    #  - string_not_empty  
-
+  - name: VW_CAPACITY_TEMPLATE_CREATE
+    columns:
+        - name: OWNER_ID
+          tests:
+          - string_not_empty   
+        - name: PARENT_CASE_TYPE
+          tests:
+          - string_not_empty
+        - name: UNIT_CASE_NAME_DISPLAY
+          tests:
+          - string_not_empty
+        - name: UNIT_CASE_IDS
+          tests:
+          - string_not_empty
+  - name: VW_UNIT_TEMPLATE_CREATE
+    columns:
+        - name: OWNER_ID
+          tests:
+          - string_not_empty   
+        - name: PARENT_CASE_ID
+          tests:
+          - string_not_empty
+        - name: CLINIC_DISPLAY_NAME
+          tests:
+          - string_not_empty
+  - name: VW_CLINICS_CREATE_UPDATE
+    columns:
+        - name: CLINIC_TYPE
+          tests:
+          - column_not_empty
+        - name: SERVICE_TYPES
+            tests:
+            - column_not_empty

--- a/models/DM/dm_views_config.yml
+++ b/models/DM/dm_views_config.yml
@@ -6,7 +6,7 @@ models:
       - not_null
       - unique
       - relationships:
-          to: source('dm_table_data', CASE_PROVIDER')
+          to: source('dm_table_data', 'CASE_PROVIDER')
           field: case_id      
     - name: CASE_TYPE
       tests:
@@ -45,5 +45,5 @@ models:
           tests:
           - column_not_empty
         - name: SERVICE_TYPES
-            tests:
-            - column_not_empty
+          tests:
+          - column_not_empty

--- a/models/DM/dm_views_config.yml
+++ b/models/DM/dm_views_config.yml
@@ -14,9 +14,9 @@ models:
       tests:
       - not_null
       - unique
-      - relationships:
-          to: source('dm_table_data', CASE_PROVIDER')
-          field: case_id      
+      #- relationships:
+      #    to: source('dm_table_data', 'custoCASE_PROVIDERmers')
+      #    field: case_id      
     - name: CASE_TYPE
       tests:
       - not_null

--- a/models/DM/dm_views_config.yml
+++ b/models/DM/dm_views_config.yml
@@ -4,12 +4,10 @@ models:
     - name: CLINIC_TYPE
       tests:
       - string_not_empty
-      - column_not_empty
     columns:
     - name: DISPLAY_NAME
       tests:
-      - string_not_empty
-      - column_not_empty     
+      - string_not_empty   
   - name: VW_CAPACITY_UPDATE
     columns:
     - name: CASE_ID

--- a/models/DM/dm_views_config.yml
+++ b/models/DM/dm_views_config.yml
@@ -1,13 +1,15 @@
 models:
-  - name: VW_CLINIC_CREATE_UPDATE
+  - name: VW_CLINICS_CREATE_UPDATE
     columns:
     - name: CLINIC_TYPE
       tests:
       - string_not_empty
+      - column_not_empty
     columns:
     - name: DISPLAY_NAME
       tests:
-      - string_not_empty     
+      - string_not_empty
+      - column_not_empty     
   - name: VW_CAPACITY_UPDATE
     columns:
     - name: CASE_ID
@@ -48,11 +50,3 @@ models:
         - name: CLINIC_DISPLAY_NAME
           tests:
           - string_not_empty
-  - name: VW_CLINICS_CREATE_UPDATE
-    columns:
-        - name: CLINIC_TYPE
-          tests:
-          - column_not_empty
-        - name: SERVICE_TYPES
-          tests:
-          - column_not_empty

--- a/tests/check_clinic_case_name_not_duplicate_creation.sql
+++ b/tests/check_clinic_case_name_not_duplicate_creation.sql
@@ -1,0 +1,11 @@
+with 
+dm_table_data_clinic_open as (
+    select * from  {{ source('dm_table_data', 'CASE_CLINIC') }}
+    where closed = false 
+)
+
+select * 
+from  VW_CLINICS_CREATE_UPDATE 
+where
+    action = 'create'
+    and case_name in (select case_name from dm_table_data_clinic_open)

--- a/tests/check_clinic_external_id_not_duplicate_creation.sql
+++ b/tests/check_clinic_external_id_not_duplicate_creation.sql
@@ -1,0 +1,11 @@
+with 
+dm_table_data_clinic_open as (
+    select * from  {{ source('dm_table_data', 'CASE_CLINIC') }}
+    where closed = false 
+)
+
+select * 
+from  VW_CLINICS_CREATE_UPDATE 
+where
+    action = 'create'
+    and ladders_external_id in (select external_id from dm_table_data_clinic_open)

--- a/tests/check_vw_ladders_api_payload.sql
+++ b/tests/check_vw_ladders_api_payload.sql
@@ -1,0 +1,8 @@
+select payloadObj.value:case_type::string case_type_value, 
+       payloadObj.value:create::string create_value,
+       payloadObj.value:clinic_case_name_display::string clinic_case_name_display_value
+from {{ ref('VW_LADDERS_API_PAYLOAD')}},
+      lateral flatten(input => parse_json(payload)) payloadObj
+where create_value=false 
+      and case_type_value='capacity'
+      and clinic_case_name_display_value=''   

--- a/tests/generic/column_not_empty.sql
+++ b/tests/generic/column_not_empty.sql
@@ -1,0 +1,6 @@
+{% test column_not_empty(model, column_name) %}
+select count ({{ column_name }}) column_count,
+count(*) total_count,
+from {{ model }}
+having  column_count = 0 and total_count > 0
+{% endtest %}


### PR DESCRIPTION
[data unit test for all DM views in snowflake gcp part 1](https://dimagi.atlassian.net/browse/UDA-1871)

**Changes made:**

1.  Add singular test that checks if a new clinic created has same case_name as an existing open clinic case - _check_clinic_case_name_not_duplicate_creation.sql_
2.  Add singular test that checks if a new clinic created has same external_id as an existing open clinic case - _check_clinic_external_id_not_duplicate_creation.sql_
3. Add generic test to check that a column is not entirely empty when the table is not empty (_currently not used_) -_tests/generic/column_not_empty.sql_ 
4. Apply string_not_empty test to additional fields in VW_CAPACITY_TEMPLATE_CREATE,  VW_UNIT_TEMPLATE_CREATE