### PR TITLE
Exclude null unit_case_ids. Nulls the entire output

### DIFF
--- a/models/DM/VW_CAPACITY_TEMPLATE_CREATE.sql
+++ b/models/DM/VW_CAPACITY_TEMPLATE_CREATE.sql
@@ -63,7 +63,7 @@ final as
         on unit.parent_case_id = clinic.case_id 
         and
         unit.case_id not in 
-            (select unit_case_ids from dm_table_data_capacity)
+            (select unit_case_ids from dm_table_data_capacity where unit_case_ids is not null)
         and unit.closed = false
 ) 
 select


### PR DESCRIPTION
This was causing all the records to be null, therefore, no template capacity cases were ever created.