### PR TITLE
add authenticator field and value for all targets

### DIFF
--- a/profiles.yml
+++ b/profiles.yml
@@ -11,6 +11,7 @@ data_and_analytics_dbt_bha_ladders:
       type: snowflake
       user: "{{ env_var('DBT_SNOWFLAKE_USER_BHA') }}"
       warehouse: COMPUTE_WH
+      authenticator: username_password_mfa
     qa:
       account: "{{ env_var('DBT_SNOWFLAKE_GCP_ACCOUNT') }}"
       database: DM_LADDERS_QA
@@ -21,6 +22,7 @@ data_and_analytics_dbt_bha_ladders:
       type: snowflake
       user: "{{ env_var('DBT_SNOWFLAKE_USER_BHA') }}"
       warehouse: COMPUTE_WH
+      authenticator: username_password_mfa
     prod:
       account: "{{ env_var('DBT_SNOWFLAKE_GCP_ACCOUNT') }}"
       database: DM_LADDERS_PROD
@@ -30,7 +32,8 @@ data_and_analytics_dbt_bha_ladders:
       threads: 1
       type: snowflake
       user: "{{ env_var('DBT_SNOWFLAKE_USER_BHA') }}"
-      warehouse: COMPUTE_WH      
+      warehouse: COMPUTE_WH
+      authenticator: username_password_mfa    
     test-location:
       account: "{{ env_var('DBT_SNOWFLAKE_GCP_ACCOUNT') }}"
       database: DM_LADDERS_BHA_LOCATION_REDESIGN_1
@@ -41,6 +44,7 @@ data_and_analytics_dbt_bha_ladders:
       type: snowflake
       user: "{{ env_var('DBT_SNOWFLAKE_USER') }}"
       warehouse: COMPUTE_WH
+      authenticator: username_password_mfa
     test-perf:
       account: "{{ env_var('DBT_SNOWFLAKE_GCP_ACCOUNT') }}"
       database: DM_LADDERS_PERF
@@ -51,6 +55,7 @@ data_and_analytics_dbt_bha_ladders:
       type: snowflake
       user: "{{ env_var('DBT_SNOWFLAKE_USER') }}"
       warehouse: COMPUTE_WH
+      authenticator: username_password_mfa
     test-train:
       account: "{{ env_var('DBT_SNOWFLAKE_GCP_ACCOUNT') }}"
       database: DM_LADDERS_TRAIN
@@ -60,7 +65,8 @@ data_and_analytics_dbt_bha_ladders:
       threads: 1
       type: snowflake
       user: "{{ env_var('DBT_SNOWFLAKE_USER') }}"
-      warehouse: COMPUTE_WH      
+      warehouse: COMPUTE_WH
+      authenticator: username_password_mfa    
     test:
       account: "{{ env_var('DBT_SNOWFLAKE_GCP_ACCOUNT') }}"
       database: DM_LADDERS_TEST
@@ -70,7 +76,8 @@ data_and_analytics_dbt_bha_ladders:
       threads: 1
       type: snowflake
       user: "{{ env_var('DBT_SNOWFLAKE_USER') }}"
-      warehouse: COMPUTE_WH     
+      warehouse: COMPUTE_WH
+      authenticator: username_password_mfa     
     test-staging:
       account: "{{ env_var('DBT_SNOWFLAKE_GCP_ACCOUNT') }}"
       database: DM_LADDERS_TEST_STAGING
@@ -80,4 +87,5 @@ data_and_analytics_dbt_bha_ladders:
       threads: 1
       type: snowflake
       user: "{{ env_var('DBT_SNOWFLAKE_USER') }}"
-      warehouse: COMPUTE_WH             
+      warehouse: COMPUTE_WH
+      authenticator: username_password_mfa            


### PR DESCRIPTION
In the profiles.yml, include the authenticator field and value. This is to prevent DUO from pinging per model when running tests, and show commands. 
`authenticator: username_password_mfa`