### PR TITLE
Exclude edge case clinics that do not actually require site_code and …

### DIFF
--- a/models/DM/VW_EXTERNAL_ID_UPDATE.sql
+++ b/models/DM/VW_EXTERNAL_ID_UPDATE.sql
@@ -11,13 +11,26 @@ dm_table_data_clinic as (
         * 
       from  {{ source('dm_table_data', 'CASE_PROVIDER') }} where closed = 'FALSE' and external_id is not null
 )
+-- BR: these clinics/providers are edge case clinics that do not meet the expectation of legacy and bhe clinics having different id's. 
+,hades_table_exclude_bhe_in_legacy as ( 
+    select * from 
+        {{ source('hades_table_data', 'VWS_LADDERS_MAPPED_ACTIVE_LICENSES') }}
+    where upper(account_id) not in 
+        ( 
+        '0014M00002QMJBGQAP',  --Young People in Recovery
+        '0014M00002QMJ2CQAX', -- The Apprentice of Peace Youth Organization dba Trailhead Institute 
+        '0014M00002QMIRYQA5', -- Advocates for Recovery Colorado
+        '0014M00002QMI2YQAH', -- Built To Recover 
+        '0014M00002QMKX0QAP' --Face It TOGETHER 
+        )
+)  
 ,hades_table_data_mapped_active_licenses as (
       select 
         replace(dm.external_id_format(legacy_parent_account_id), '_', '') || '-' || replace(dm.external_id_format(legacy_account_id), '_', '') as legacy_clinic_external_id,
         dm.external_id_format(parent_account_id) || '-' || dm.external_id_format(account_id) as new_clinic_external_id,
         replace(dm.external_id_format(legacy_parent_account_id), '_', '') as legacy_provider_external_id,
         dm.external_id_format(parent_account_id) as new_provider_external_id,
-        * from {{ source('hades_table_data', 'VWS_LADDERS_MAPPED_ACTIVE_LICENSES') }}
+        * from hades_table_exclude_bhe_in_legacy --{{ source('hades_table_data', 'VWS_LADDERS_MAPPED_ACTIVE_LICENSES') }}
       where legacy_parent_account_id is not null and legacy_account_id is not null
       and parent_account_id is not null and account_id is not null
 )


### PR DESCRIPTION
[Repeat updates for some provider and clinics
](https://dimagi.atlassian.net/jira/software/projects/UDA/boards/227?assignee=60a1962f2614ec006899bca4&selectedIssue=UDA-2044)

**Context**: These records are edge cases because they are  BHE records, but were added to the legacy system, and now have the exact same `account_id` and `legacy_account_id` and `parent_account_id` and `legacy_parent_account_id`, which is not what our logic is set up and goes against the original problem (different legacy and bhe ids). 

**These PR**: Exclude these records from being included into the `site_code` update and `external_id` update logic because they do not need that update. But currently, these records are always being included into the site_code and external_id update, and never be included into the `VW_LADDERS_MAPPED_INTEGRATION_TABLE`.